### PR TITLE
Fix user defined executors options

### DIFF
--- a/lua/present.lua
+++ b/lua/present.lua
@@ -69,8 +69,8 @@ M.setup = function(opts)
   opts.executors = opts.executors or {}
 
   opts.executors.lua = opts.executors.lua or execute_lua_code
-  opts.executors.javascript = opts.executors.lua or M.create_system_executor "node"
-  opts.executors.python = opts.executors.lua or M.create_system_executor "python"
+  opts.executors.javascript = opts.executors.javascript or M.create_system_executor "node"
+  opts.executors.python = opts.executors.python or M.create_system_executor "python"
 
   options = opts
 end


### PR DESCRIPTION
Hey TJ, thanks so much for your Advent of Neovim series on YouTube! It's been the best thing to watch this month!

Anyways, I just noticed this part that you missed in part 8 of the series, and I think without this fix it would try to use a user-defined Lua executor for JavaScript and Python!

Keep up the great work, this has been really enlightening and inspiring me to try make my own plugin!