### PR TITLE
fix: ignore pound char inside codeblock

### DIFF
--- a/lua/present.lua
+++ b/lua/present.lua
@@ -116,9 +116,16 @@ local parse_slides = function(lines)
   }
 
   local separator = "^#"
+  local inside_code_block = false
 
   for _, line in ipairs(lines) do
-    if line:find(separator) then
+    -- Check for code block boundaries
+    if vim.startswith(line, "```") then
+      inside_code_block = not inside_code_block
+    end
+
+     -- Only process as slide separator if we're not inside a code block
+    if line:find(separator) and not inside_code_block then
       if #current_slide.title > 0 then
         table.insert(slides.slides, current_slide)
       end

--- a/tests/parse_slides_spec.lua
+++ b/tests/parse_slides_spec.lua
@@ -58,4 +58,34 @@ describe("present.parse_slides", function()
       body = "print('hi')",
     }, slide.blocks[1])
   end)
+
+  it('should not treat # inside code blocks as new slides', function()
+    local results = parse {
+      '# Main slide',
+      'Some content',
+      '```bash',
+      '#this is a comment',
+      'echo hello',
+      '```',
+      'More content',
+    }
+
+    -- Should only have one slide
+    eq(1, #results.slides)
+
+    local slide = results.slides[1]
+    eq('# Main slide', slide.title)
+    eq({
+      'Some content',
+      '```bash',
+      '#this is a comment',
+      'echo hello',
+      '```',
+      'More content',
+    }, slide.body)
+    eq({
+      language = 'bash',
+      body = '#this is a comment\necho hello',
+    }, slide.blocks[1])
+  end)
 end)


### PR DESCRIPTION
Hey TJ 

I encountered a bug while working on a C executor. Specifically, #include statements are being incorrectly parsed as new slides, which interrupts the expected behavior.

Happy new year!