### PR TITLE
Fix: plugin loses custom options

### DIFF
--- a/plugin/load_present.lua
+++ b/plugin/load_present.lua
@@ -1,6 +1,3 @@
 vim.api.nvim_create_user_command("PresentStart", function()
-  -- Easy Reloading
-  package.loaded["present"] = nil
-
   require("present").start_presentation()
 end, {})


### PR DESCRIPTION
Hello @tjdevries 

Thank you for the plugin! Here is a little fix (I think)...

Problem: Custom options are missing when launching the presentation. The previous plugin load is deleted when invoking the PresentStart command.

Debugging: Use `vim.inspect(options)` to trace M.options...

Fix: Prevent options from losing their configuration context when calling the presentation.
